### PR TITLE
Improve about page language handling

### DIFF
--- a/public/css/about.css
+++ b/public/css/about.css
@@ -24,17 +24,7 @@
   margin-top: 1rem;
 }
 
-/* Show content based on language */
-#content-en,
-#content-zh {
-  display: none;
-}
-html[lang|="en"] #content-en {
-  display: block;
-}
-html[lang|="zh"] #content-zh {
-  display: block;
-}
+
 
 /* Override global body flex alignment so main follows nav at the top */
 body,

--- a/public/js/about.js
+++ b/public/js/about.js
@@ -1,6 +1,7 @@
 (function () {
   function applyLang() {
     var data = window.aboutPageData || {};
+    var contentData = window.aboutPageContent || {};
     var storedLang = localStorage.getItem('preferred_lang');
     var lang = storedLang || 'zh-CN';
     var showZh = lang.startsWith('zh');
@@ -12,6 +13,46 @@
       document.title = showZh ? data.titles.zh : data.titles.en;
       if (meta) {
         meta.setAttribute('content', showZh ? data.descriptions.zh : data.descriptions.en);
+      }
+    }
+
+    if (contentData.zh && contentData.en) {
+      var current = showZh ? contentData.zh : contentData.en;
+      var container = document.getElementById('content');
+      if (container) {
+        var h1 = container.querySelector('#heroHeading');
+        if (h1) h1.innerHTML = current.heroHeading;
+        var title = container.querySelector('#aboutTitle');
+        if (title) title.textContent = current.title;
+        var ps = container.querySelector('#aboutParagraphs');
+        if (ps) {
+          ps.innerHTML = '';
+          current.paragraphs.forEach(function (p) {
+            var el = document.createElement('p');
+            el.textContent = p;
+            ps.appendChild(el);
+          });
+        }
+        var info = container.querySelector('#aboutInfo');
+        if (info) {
+          info.innerHTML = '';
+          current.info.forEach(function (item) {
+            var li = document.createElement('li');
+            var span = document.createElement('span');
+            span.textContent = item.label;
+            li.appendChild(span);
+            li.appendChild(document.createTextNode(item.value));
+            info.appendChild(li);
+          });
+        }
+        var resume = container.querySelector('#resumeLink');
+        if (resume) {
+          resume.textContent = current.resumeLabel;
+          if (data.resumePaths && data.resumeDownloads) {
+            resume.setAttribute('href', showZh ? data.resumePaths.zh : data.resumePaths.en);
+            resume.setAttribute('download', showZh ? data.resumeDownloads.zh : data.resumeDownloads.en);
+          }
+        }
       }
     }
   }

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -14,8 +14,13 @@ import { ABOUT_CONTENT } from '../content/aboutContent.js';
 
 const aboutPageData = {
   titles: { en: PAGE_TITLES.ABOUT_EN, zh: PAGE_TITLES.ABOUT_ZH },
-  descriptions: { en: SITE_DESCRIPTION_EN, zh: SITE_DESCRIPTION_ZH }
+  descriptions: { en: SITE_DESCRIPTION_EN, zh: SITE_DESCRIPTION_ZH },
+  resumePaths: { en: IMAGE_PATHS.RESUME_EN, zh: IMAGE_PATHS.RESUME_ZH },
+  resumeDownloads: { en: RESUME_EN_DOWNLOAD, zh: RESUME_ZH_DOWNLOAD }
 };
+
+const langDefault = 'zh';
+const content = ABOUT_CONTENT[langDefault];
 ---
 
 <BaseLayout
@@ -26,40 +31,18 @@ const aboutPageData = {
   extraStyles={['/css/about.css']}
   extraScripts={['/js/about.js']}
 >
-  <div id="content-en">
+  <div id="content">
     <section class="hero">
-      <h1 set:html={ABOUT_CONTENT.en.heroHeading} />
+      <h1 id="heroHeading" set:html={content.heroHeading} />
     </section>
     <section class="about-section">
-      <h2>{ABOUT_CONTENT.en.title}</h2>
-      {ABOUT_CONTENT.en.paragraphs.map((p) => <p>{p}</p>)}
-      <ul>
-        {
-          ABOUT_CONTENT.en.info.map(({ label, value }) => (
-            <li>
-              <span>{label}</span>
-              {value}
-            </li>
-          ))
-        }
-      </ul>
-      <div class="resume-link">
-        <a href={IMAGE_PATHS.RESUME_EN} download={RESUME_EN_DOWNLOAD} class="btn btn-primary"
-          >{ABOUT_CONTENT.en.resumeLabel}</a
-        >
+      <h2 id="aboutTitle">{content.title}</h2>
+      <div id="aboutParagraphs">
+        {content.paragraphs.map((p) => <p>{p}</p>)}
       </div>
-    </section>
-  </div>
-  <div id="content-zh">
-    <section class="hero">
-      <h1 set:html={ABOUT_CONTENT.zh.heroHeading} />
-    </section>
-    <section class="about-section">
-      <h2>{ABOUT_CONTENT.zh.title}</h2>
-      {ABOUT_CONTENT.zh.paragraphs.map((p) => <p>{p}</p>)}
-      <ul>
+      <ul id="aboutInfo">
         {
-          ABOUT_CONTENT.zh.info.map(({ label, value }) => (
+          content.info.map(({ label, value }) => (
             <li>
               <span>{label}</span>
               {value}
@@ -68,16 +51,21 @@ const aboutPageData = {
         }
       </ul>
       <div class="resume-link">
-        <a href={IMAGE_PATHS.RESUME_ZH} download={RESUME_ZH_DOWNLOAD} class="btn btn-primary"
-          >{ABOUT_CONTENT.zh.resumeLabel}</a
+        <a
+          id="resumeLink"
+          href={IMAGE_PATHS.RESUME_ZH}
+          download={RESUME_ZH_DOWNLOAD}
+          class="btn btn-primary"
+          >{content.resumeLabel}</a
         >
       </div>
     </section>
   </div>
 
   <Fragment slot="head">
-    <script define:vars={{ aboutPageData }}>
+    <script define:vars={{ aboutPageData, aboutPageContent: ABOUT_CONTENT }}>
       window.aboutPageData = aboutPageData;
+      window.aboutPageContent = aboutPageContent;
     </script>
   </Fragment>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- show about page content dynamically for the selected language
- remove duplicated markup and CSS
- update client script to fill content based on language

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68867a2ce9e083339dec7a8b13db87db